### PR TITLE
Add raise keyword for templates

### DIFF
--- a/jenskipper/exceptions.py
+++ b/jenskipper/exceptions.py
@@ -1,3 +1,6 @@
+import jinja2.exceptions
+
+
 class JenskipperError(Exception):
 
     pass
@@ -66,5 +69,13 @@ class MalformedBuildParameter(JenskipperError):
 
 
 class BuildIsNotParametrized(JenskipperError):
+
+    pass
+
+
+class TemplateUserError(jinja2.exceptions.TemplateRuntimeError):
+    """
+    Raised by the {% raise 'error' %} extension.
+    """
 
     pass

--- a/tests/data/template_with_raise.txt
+++ b/tests/data/template_with_raise.txt
@@ -1,0 +1,3 @@
+foo
+bar
+{% raise "baz" %}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,6 +3,7 @@ import sys
 import jinja2
 
 from jenskipper import templates
+from jenskipper import exceptions
 
 
 def test_render(data_dir):
@@ -71,3 +72,17 @@ def test_track_includes(data_dir):
         data_dir.join('template_with_include.txt'),
         data_dir.join('template.txt')
     }
+
+
+def test_template_with_raise(data_dir):
+    tpl_name = 'template_with_raise.txt'
+    try:
+        templates.render(unicode(data_dir), tpl_name, {})
+    except exceptions.TemplateUserError:
+        stack, error = templates.extract_jinja_error(sys.exc_info())
+    tpl_path = data_dir.join(tpl_name)
+    assert stack == [
+        '  File "%s", line 3' % tpl_path,
+        '    {% raise "baz" %}',
+    ]
+    assert error == 'User error: baz'


### PR DESCRIPTION
Allows users to raise errors from templates:

```
{% if var == 'bar' %}
bar
{% elif var == 'baz %}
baz
{% else %}
    {% raise 'illegal value for var: %s' % var %}
{% endif %}
```