### PR TITLE
Add `jk check` command

### DIFF
--- a/jenskipper/cli/check.py
+++ b/jenskipper/cli/check.py
@@ -1,0 +1,45 @@
+import sys
+
+import click
+import jinja2
+
+from . import decorators
+from .. import repository
+from .. import templates
+
+
+@click.command()
+@decorators.repos_command
+@decorators.jobs_command()
+@click.pass_context
+def check(context, jobs_names, base_dir):
+    """
+    Check JOBS templates render correctly.
+    """
+    if not jobs_names:
+        context.exit(0)
+
+    ret = 0
+    for job in jobs_names:
+        click.secho('Checking %s' % job, fg='green')
+        try:
+            repository.get_job_conf(base_dir, job)
+        except jinja2.TemplateNotFound as exc:
+            click.secho('    Template not found: %s' % exc.name, fg='red',
+                        bold=True)
+            click.secho('')
+            ret |= 1
+        except jinja2.TemplateError:
+            exc_info = sys.exc_info()
+            stack, error = templates.extract_jinja_error(exc_info, base_dir)
+            templates.print_jinja_error(stack, error, lines_prefix='    ')
+            click.secho('')
+            ret |= 2
+
+    click.secho('')
+    if ret == 0:
+        click.secho('All good!', fg='green', bold=True)
+    else:
+        click.secho('There were some errors :(', fg='red', bold=True)
+
+    context.exit(ret)

--- a/jenskipper/cli/main.py
+++ b/jenskipper/cli/main.py
@@ -18,6 +18,7 @@ from .get_artifact import get_artifact
 from .status import get_job_status
 from .auth import authenticate
 from .delete import delete
+from .check import check
 
 
 @click.group()
@@ -50,3 +51,4 @@ main.add_command(get_artifact)
 main.add_command(get_job_status)
 main.add_command(authenticate)
 main.add_command(delete)
+main.add_command(check)

--- a/jenskipper/templates.py
+++ b/jenskipper/templates.py
@@ -66,13 +66,13 @@ def extract_jinja_error(exc_info, fnames_prefix=None):
     return stack_lines, u'%s: %s' % (prefix, error_details)
 
 
-def print_jinja_error(stack_lines, error):
-    click.secho('Traceback (most recent call last):')
+def print_jinja_error(stack_lines, error, lines_prefix=''):
+    click.secho(lines_prefix + 'Traceback (most recent call last):')
     click.secho('')
     for line in stack_lines:
-        click.secho(line)
+        click.secho(lines_prefix + line)
     click.secho('')
-    click.secho(error, fg='red', bold=True)
+    click.secho(lines_prefix + error, fg='red', bold=True)
 
 
 class TrackingFileSystemLoader(jinja2.FileSystemLoader):

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -1,0 +1,19 @@
+from jenskipper.cli import check
+
+
+def test_check_good_template():
+    assert check.check(['default_job'], standalone_mode=False) == 0
+
+
+def test_check_missing_template():
+    assert check.check(['missing_template'], standalone_mode=False) == 1
+
+
+def test_check_template_errors():
+    assert check.check(['syntax_error'], standalone_mode=False) == 2
+    assert check.check(['undefined_var'], standalone_mode=False) == 2
+
+
+def test_check_errors_combine():
+    assert check.check(['syntax_error', 'missing_template'],
+                       standalone_mode=False) == 3


### PR DESCRIPTION
Allows to easily check that jobs templates render correctly within the
project.