### PR TITLE
push: handle push new job + disable_jobs_from_gui

### DIFF
--- a/jenskipper/cli/push.py
+++ b/jenskipper/cli/push.py
@@ -109,8 +109,13 @@ def _push_jobs(session, jobs_names, progress_bar, base_dir, pipelines,
                                         insert_hash=True,
                                         context_overrides=context_overrides)
         if conf.get(base_dir, ['server', 'disable_jobs_from_gui']):
-            server_conf = jenkins_api.get_job_config(session, job_name)
-            final_conf = jobs.transfuse_disabled_flag(server_conf, final_conf)
+            try:
+                server_conf = jenkins_api.get_job_config(session, job_name)
+                final_conf = jobs.transfuse_disabled_flag(server_conf,
+                                                          final_conf)
+            except exceptions.JobNotFound:
+                # Job does not exist on server, nothing to do
+                pass
         try:
             jenkins_api.push_job_config(
                 session,


### PR DESCRIPTION
Fixed the case where we try to push a new job to the server and the
jobs repository is configured with disable_jobs_from_gui = true.

In this case the server will return a 404 when we try to retrieve the
job's XML from it to inject the disabled flag in the to-be-pushed XML,
and we just have to ignore the error and push the local XML as-is.